### PR TITLE
update RejectedByOwnerAsync

### DIFF
--- a/TimeOffTracker.WebApi/Controllers/RequestController.cs
+++ b/TimeOffTracker.WebApi/Controllers/RequestController.cs
@@ -73,7 +73,7 @@ namespace TimeOffTracker.WebApi.Controllers
             await _service.UpdateAsync(requestId, newModel);
         }
 
-        [Authorize(Roles = "Manager, Accountant, Admin")]
+        [Authorize(Roles = RoleName.manager + "," + RoleName.accountant + "," + RoleName.admin)]
         [HttpDelete("/requests/{requestId}")]
         public async Task Delete(int requestId)
         {


### PR DESCRIPTION
Не заметил, что логика отмены создателем применима ко всем состояниям (кроме Rejected).
Согласно ТЗ: "До первого утверждения сотрудник может полностью изменить заявку на отпуск или удалить ее."
Теперь при отмене заявки New, она просто удаляется вместе со своими ревью